### PR TITLE
feat: Implement Pub/Sub provisioning for AI agent inboxes

### DIFF
--- a/gcp/pubsub_setup/README.md
+++ b/gcp/pubsub_setup/README.md
@@ -1,0 +1,211 @@
+# Google Cloud Pub/Sub Setup for AI Agent Inboxes
+
+This directory contains scripts and documentation for provisioning Google Cloud Pub/Sub topics and subscriptions that serve as inboxes for individual AI Agents. This setup is crucial for the AI Agent Message Routing Component.
+
+## Table of Contents
+1. [Overview](#overview)
+2. [Naming Conventions](#naming-conventions)
+    - [Agent Address Sanitization and Hashing](#agent-address-sanitization-and-hashing)
+    - [Pub/Sub Topic Naming](#pubsub-topic-naming)
+    - [Pub/Sub Subscription Naming](#pubsub-subscription-naming)
+    - [DLQ Topic Naming](#dlq-topic-naming)
+3. [Pub/Sub Configuration](#pubsub-configuration)
+    - [Main Agent Topic](#main-agent-topic)
+    - [DLQ Topic](#dlq-topic)
+    - [Subscription](#subscription)
+4. [IAM Permissions (Conceptual)](#iam-permissions-conceptual)
+5. [Provisioning Script (`pubsub_provisioning.py`)](#provisioning-script-pubsub_provisioningpy)
+    - [Prerequisites](#prerequisites)
+    - [Usage](#usage)
+    - [Example](#example)
+6. [Manual Verification/Creation with `gcloud`](#manual-verificationcreation-with-gcloud)
+    - [Setting Project ID](#setting-project-id)
+    - [Creating Topics](#creating-topics)
+    - [Creating Subscription with DLQ](#creating-subscription-with-dlq)
+    - [Verifying Resources](#verifying-resources)
+
+## 1. Overview
+
+Each AI Agent requires a dedicated Pub/Sub topic (its "inbox") and a corresponding subscription for message consumption. To handle message processing failures, each subscription is configured with a Dead Letter Queue (DLQ), which is itself another Pub/Sub topic.
+
+The provisioning of these resources is intended to be dynamic, typically triggered when a new AI Agent is registered with a central service. The provided Python script (`pubsub_provisioning.py`) automates this setup.
+
+## 2. Naming Conventions
+
+Consistent naming is vital for manageability. All names are derived from the AI Agent's address (e.g., `agent-sales@yourorg.com`).
+
+### Agent Address Sanitization and Hashing
+
+To ensure names are unique, URL-safe, and conform to Pub/Sub naming restrictions (length, characters), the `aiAgentAddress` undergoes a sanitization and hashing process:
+1.  **Lowercase Conversion:** The address is converted to lowercase (e.g., `agent-sales@yourorg.com` -> `agent-sales@yourorg.com`).
+2.  **Sanitization:** Non-alphanumeric characters (any character not `a-z`, `0-9`) are replaced with hyphens (`-`). Multiple consecutive hyphens are collapsed into a single hyphen. Leading/trailing hyphens are removed.
+    *   Example: `agent-sales.support@example-org.com` becomes `agent-sales-support-example-org-com`.
+3.  **Hashing:** The sanitized string is then hashed using **SHA-256**. The hexadecimal representation of this hash is used in resource names.
+    *   Example Hash (truncated for brevity): `1c3a2b4f...`
+
+Let `<hashed-address>` represent the result of this process.
+
+### Pub/Sub Topic Naming (Agent Inbox)
+*   **Format:** `agent-inbox-<hashed-address>`
+*   **Example:** `agent-inbox-1c3a2b4f...`
+*   **Constraints:** Pub/Sub topic names must start with a letter and contain only letters, numbers, dashes (`-`), periods (`.`), underscores (`_`), tildes (`~`), plus signs (`+`), and percent signs (`%`). Max length 255 characters. The prefix `agent-inbox-` ensures it starts with a letter, and the SHA-256 hash (64 hex characters) fits well within length limits.
+
+### Pub/Sub Subscription Naming
+*   **Format:** `agent-sub-<hashed-address>-<consumer-group-id>`
+*   **Default `consumer-group-id`:** `main-consumer`
+*   **Example:** `agent-sub-1c3a2b4f...-main-consumer`
+*   **Constraints:** Similar to topic names.
+
+### DLQ Topic Naming
+*   **Format:** `dlq-agent-inbox-<hashed-address>`
+*   **Example:** `dlq-agent-inbox-1c3a2b4f...`
+*   **Constraints:** Same as other topic names.
+
+## 3. Pub/Sub Configuration
+
+### Main Agent Topic
+*   No special configuration beyond its name. Standard Pub/Sub topic defaults apply.
+
+### DLQ Topic
+*   No special configuration beyond its name. Standard Pub/Sub topic defaults apply. It serves as the destination for undeliverable messages.
+
+### Subscription
+*   **Type:** Pull Subscription.
+*   **Acknowledgement Deadline:** `10 seconds`. This is the time the subscriber has to acknowledge a message before Pub/Sub redelivers it.
+*   **Message Retention Duration:** `7 days`. How long messages are retained, even if acknowledged (though `retain_acked_messages` is typically false for pull subscriptions).
+*   **Enable Message Ordering:** No (not configured, defaults to false).
+*   **Dead Letter Queue (DLQ) Configuration:**
+    *   **Dead Letter Topic:** The corresponding `dlq-agent-inbox-<hashed-address>` topic.
+    *   **Maximum Delivery Attempts:** `5`. After 5 failed delivery attempts (i.e., message not acknowledged within the deadline), the message is sent to the DLQ topic.
+
+## 4. IAM Permissions (Conceptual)
+
+The following IAM roles are conceptually required for different components interacting with these Pub/Sub resources. Apply these to the appropriate service accounts.
+
+*   **Message Router Service Account** (The component sending messages *to* agent inboxes):
+    *   Role: `roles/pubsub.publisher`
+    *   Resource: On each `agent-inbox-<hashed-address>` topic it needs to publish to, or on the project if it needs to publish to any/all such topics.
+
+*   **AI Agent Consumer Service Account** (The AI agent application consuming messages *from* its inbox):
+    *   Role: `roles/pubsub.subscriber`
+    *   Resource: On its specific `agent-sub-<hashed-address>-<consumer-group-id>` subscription.
+    *   Role: `roles/pubsub.viewer` (or `roles/pubsub.subscriber` on the DLQ subscription if one is made)
+    *   Resource: On its specific `dlq-agent-inbox-<hashed-address>` topic (if the agent needs to be aware of or process its DLQ messages, though this is often an administrative task). Typically, a separate process/administrator would handle DLQ messages.
+
+*   **Provisioning Service Account** (The service/tool responsible for creating and managing these Pub/Sub resources):
+    *   Role: `roles/pubsub.editor`
+    *   Resource: On the GCP Project. This grants broad permissions.
+    *   *Alternatively, for more fine-grained control, a custom role with permissions like:*
+        *   `pubsub.topics.create`
+        *   `pubsub.topics.get`
+        *   `pubsub.topics.update` (potentially, for modifying existing topics)
+        *   `pubsub.subscriptions.create`
+        *   `pubsub.subscriptions.get`
+        *   `pubsub.subscriptions.update` (for settings like DLQ policy)
+
+## 5. Provisioning Script (`pubsub_provisioning.py`)
+
+The `pubsub_provisioning.py` script automates the creation of the topics and subscriptions as described.
+
+### Prerequisites
+*   Python 3.7+
+*   Google Cloud SDK (`gcloud`) installed and configured.
+*   Authenticated to GCP: Run `gcloud auth application-default login`.
+*   The `google-cloud-pubsub` Python library installed:
+    ```bash
+    pip install google-cloud-pubsub
+    ```
+*   A valid GCP Project ID where resources will be created.
+
+### Usage
+The script can be run directly. It contains an example `if __name__ == "__main__":` block that demonstrates how to use the `provision_agent_inbox` function.
+
+```bash
+python pubsub_provisioning.py
+```
+You should modify the `DEFAULT_GCP_PROJECT_ID` in the script or pass the project ID dynamically to the functions if you adapt it for broader use. The example uses a placeholder project ID.
+
+### Example
+The `provision_agent_inbox(ai_agent_address, project_id)` function is the primary entry point.
+
+```python
+# From pubsub_provisioning.py
+if __name__ == "__main__":
+    gcp_project_id = "your-actual-gcp-project-id" # Replace this
+    sample_agent_address = "agent-support@example.com"
+
+    provision_agent_inbox(sample_agent_address, gcp_project_id)
+```
+
+## 6. Manual Verification/Creation with `gcloud`
+
+You can also use `gcloud` commands to manually create, inspect, or verify these resources.
+
+### Setting Project ID
+Ensure your `gcloud` is configured for the correct project:
+```bash
+gcloud config set project your-gcp-project-id
+```
+
+Replace `your-gcp-project-id` and other placeholders (like `<hash>`, `<agent-address>`) with actual values.
+The `<hash>` should be the SHA-256 hash of the sanitized agent address.
+
+### Creating Topics
+**Agent Inbox Topic:**
+```bash
+# Replace <agent-address> with the actual agent address to generate the topic name
+# Example: AGENT_ADDRESS="agent-sales@yourorg.com" (then sanitize and hash it for <hash>)
+# TOPIC_NAME="agent-inbox-<hash>"
+gcloud pubsub topics create agent-inbox-<hash>
+```
+
+**DLQ Topic:**
+```bash
+# DLQ_TOPIC_NAME="dlq-agent-inbox-<hash>"
+gcloud pubsub topics create dlq-agent-inbox-<hash>
+```
+
+### Creating Subscription with DLQ
+```bash
+# Define variables first for clarity
+# PROJECT_ID="your-gcp-project-id"
+# AGENT_ADDRESS="agent-sales@yourorg.com" (sanitize and hash for <hash>)
+# HASHED_ADDRESS="<hash>" # Result of sanitizing and hashing AGENT_ADDRESS
+#
+# MAIN_TOPIC_NAME="agent-inbox-${HASHED_ADDRESS}"
+# DLQ_TOPIC_NAME="dlq-agent-inbox-${HASHED_ADDRESS}"
+# SUBSCRIPTION_NAME="agent-sub-${HASHED_ADDRESS}-main-consumer"
+
+gcloud pubsub subscriptions create agent-sub-<hash>-main-consumer \
+    --topic agent-inbox-<hash> \
+    --dead-letter-topic projects/your-gcp-project-id/topics/dlq-agent-inbox-<hash> \
+    --max-delivery-attempts 5 \
+    --ack-deadline 10 \
+    --message-retention-duration 7d # 7 days (e.g., 7d, 604800s)
+```
+*   Ensure `your-gcp-project-id` is correctly substituted in the `--dead-letter-topic` path.
+*   `--message-retention-duration` format can be like `7d` for days or an integer number of seconds.
+*   `--ack-deadline` is in seconds.
+
+### Verifying Resources
+**List Topics:**
+```bash
+gcloud pubsub topics list
+```
+
+**Describe a Topic:**
+```bash
+gcloud pubsub topics describe agent-inbox-<hash>
+```
+
+**List Subscriptions:**
+```bash
+gcloud pubsub subscriptions list
+```
+
+**Describe a Subscription:**
+```bash
+gcloud pubsub subscriptions describe agent-sub-<hash>-main-consumer
+```
+This command will show the full configuration, including the dead letter policy.
+```

--- a/gcp/pubsub_setup/pubsub_provisioning.py
+++ b/gcp/pubsub_setup/pubsub_provisioning.py
@@ -1,0 +1,273 @@
+# -*- coding: utf-8 -*-
+"""
+Provisions Google Cloud Pub/Sub topics and subscriptions for AI Agent inboxes.
+
+This script provides functions to:
+- Generate standardized names for topics, subscriptions, and Dead Letter Queues (DLQs).
+- Create Pub/Sub topics for agent inboxes and their associated DLQs.
+- Create Pub/Sub pull subscriptions with DLQ configuration.
+"""
+
+import hashlib
+import re
+from google.cloud import pubsub_v1
+from google.api_core import exceptions as google_exceptions
+
+# Placeholder for the GCP Project ID. In a real scenario, this would be
+# dynamically passed or configured.
+DEFAULT_GCP_PROJECT_ID = "your-gcp-project-id"
+
+def _sanitize_and_hash_address(ai_agent_address: str) -> str:
+    """
+    Sanitizes an AI agent address and returns its SHA-256 hash.
+
+    Sanitization steps:
+    1. Convert to lowercase.
+    2. Replace non-alphanumeric characters (anything not a-z, 0-9) with hyphens.
+       This is a common practice before hashing to ensure consistency.
+       The task description: "convert the aiAgentAddress to lowercase,
+       replace non-alphanumeric characters with hyphens, and then take a
+       SHA-256 hash of the result".
+
+    Args:
+        ai_agent_address: The AI agent's address (e.g., "agent-sales@yourorg.com").
+
+    Returns:
+        A string representing the hexadecimal SHA-256 hash of the sanitized address.
+    """
+    sanitized_address = ai_agent_address.lower()
+    # Replace any character that is not a lowercase letter, number, or hyphen with a hyphen
+    sanitized_address = re.sub(r"[^a-z0-9\-]", "-", sanitized_address)
+    # Collapse multiple hyphens into one
+    sanitized_address = re.sub(r"-+", "-", sanitized_address)
+    # Remove leading/trailing hyphens that might result from replacements
+    sanitized_address = sanitized_address.strip('-')
+
+    hasher = hashlib.sha256()
+    hasher.update(sanitized_address.encode('utf-8'))
+    return hasher.hexdigest()
+
+def generate_topic_name(ai_agent_address: str) -> str:
+    """
+    Generates a Pub/Sub topic name for an AI agent's inbox.
+
+    Format: agent-inbox-<aiAgentAddress-sanitized-hash>
+
+    Args:
+        ai_agent_address: The AI agent's address.
+
+    Returns:
+        The generated Pub/Sub topic name.
+    """
+    hashed_address = _sanitize_and_hash_address(ai_agent_address)
+    return f"agent-inbox-{hashed_address}"
+
+def generate_dlq_topic_name(ai_agent_address: str) -> str:
+    """
+    Generates a Pub/Sub topic name for the Dead Letter Queue (DLQ)
+    associated with an AI agent's inbox.
+
+    Format: dlq-agent-inbox-<aiAgentAddress-sanitized-hash>
+
+    Args:
+        ai_agent_address: The AI agent's address.
+
+    Returns:
+        The generated DLQ topic name.
+    """
+    hashed_address = _sanitize_and_hash_address(ai_agent_address)
+    return f"dlq-agent-inbox-{hashed_address}"
+
+def generate_subscription_name(ai_agent_address: str, consumer_group_id: str = "main-consumer") -> str:
+    """
+    Generates a Pub/Sub subscription name for an AI agent's inbox.
+
+    Format: agent-sub-<aiAgentAddress-sanitized-hash>-<consumer-group-id>
+
+    Args:
+        ai_agent_address: The AI agent's address.
+        consumer_group_id: Identifier for the consumer group (default: "main-consumer").
+
+    Returns:
+        The generated Pub/Sub subscription name.
+    """
+    hashed_address = _sanitize_and_hash_address(ai_agent_address)
+    return f"agent-sub-{hashed_address}-{consumer_group_id}"
+
+def create_topic_if_not_exists(project_id: str, topic_name: str) -> str:
+    """
+    Creates a Pub/Sub topic if it doesn't already exist.
+
+    Args:
+        project_id: The GCP project ID.
+        topic_name: The name for the topic.
+
+    Returns:
+        The fully qualified topic path.
+    """
+    publisher = pubsub_v1.PublisherClient()
+    topic_path = publisher.topic_path(project_id, topic_name)
+
+    try:
+        publisher.create_topic(request={"name": topic_path})
+        print(f"Topic created: {topic_path}")
+    except google_exceptions.AlreadyExists:
+        print(f"Topic already exists: {topic_path}")
+    except Exception as e:
+        print(f"An error occurred while creating topic {topic_path}: {e}")
+        raise
+    return topic_path
+
+def create_subscription_with_dlq(
+    project_id: str,
+    topic_path: str,
+    subscription_name: str,
+    dlq_topic_path: str
+) -> str:
+    """
+    Creates a Pub/Sub pull subscription with a Dead Letter Queue (DLQ) configuration.
+
+    Args:
+        project_id: The GCP project ID.
+        topic_path: The fully qualified path of the main topic to subscribe to.
+        subscription_name: The name for the subscription.
+        dlq_topic_path: The fully qualified path of the DLQ topic.
+
+    Returns:
+        The fully qualified subscription path.
+    """
+    subscriber = pubsub_v1.SubscriberClient()
+    subscription_path = subscriber.subscription_path(project_id, subscription_name)
+
+    dead_letter_policy = pubsub_v1.types.DeadLetterPolicy(
+        dead_letter_topic=dlq_topic_path,
+        max_delivery_attempts=5,
+    )
+
+    # Default acknowledgement deadline is 10 seconds.
+    # Default message retention duration is 7 days.
+    # These are standard defaults and often don't need to be explicitly set
+    # unless a deviation from the default is required.
+    # The google-cloud-pubsub library will use these defaults if not specified.
+
+    request = {
+        "name": subscription_path,
+        "topic": topic_path,
+        "dead_letter_policy": dead_letter_policy,
+        "ack_deadline_seconds": 10, # Explicitly set as per requirements
+        "retain_acked_messages": False, # Standard behavior
+        "message_retention_duration": {"seconds": 60 * 60 * 24 * 7} # 7 days
+    }
+
+    try:
+        subscriber.create_subscription(request=request)
+        print(f"Subscription created: {subscription_path} for topic {topic_path}")
+        print(f"  - DLQ Topic: {dlq_topic_path}")
+        print(f"  - Max Delivery Attempts: {dead_letter_policy.max_delivery_attempts}")
+        print(f"  - Ack Deadline: 10 seconds")
+        print(f"  - Message Retention: 7 days")
+    except google_exceptions.AlreadyExists:
+        print(f"Subscription already exists: {subscription_path}")
+    except Exception as e:
+        print(f"An error occurred while creating subscription {subscription_path}: {e}")
+        raise
+    return subscription_path
+
+def provision_agent_inbox(ai_agent_address: str, project_id: str):
+    """
+    Provisions a complete Pub/Sub inbox (topic, DLQ topic, subscription) for an AI agent.
+
+    Args:
+        ai_agent_address: The AI agent's address.
+        project_id: The GCP project ID.
+    """
+    print(f"\nProvisioning Pub/Sub resources for agent: {ai_agent_address} in project: {project_id}")
+
+    # Generate names
+    agent_topic_name = generate_topic_name(ai_agent_address)
+    dlq_topic_name_str = generate_dlq_topic_name(ai_agent_address)
+    subscription_name_str = generate_subscription_name(ai_agent_address)
+
+    # Create DLQ topic first (as it's referenced by the subscription)
+    print(f"\nStep 1: Ensure DLQ topic exists ({dlq_topic_name_str})")
+    dlq_topic_path = create_topic_if_not_exists(project_id, dlq_topic_name_str)
+
+    # Create main agent inbox topic
+    print(f"\nStep 2: Ensure main agent inbox topic exists ({agent_topic_name})")
+    agent_topic_path = create_topic_if_not_exists(project_id, agent_topic_name)
+
+    # Create subscription with DLQ
+    print(f"\nStep 3: Ensure subscription with DLQ exists ({subscription_name_str})")
+    create_subscription_with_dlq(
+        project_id,
+        agent_topic_path,
+        subscription_name_str,
+        dlq_topic_path
+    )
+    print(f"\nSuccessfully provisioned resources for {ai_agent_address}")
+
+if __name__ == "__main__":
+    # Example Usage:
+    # Replace with your actual project ID and desired agent addresses
+    gcp_project_id = DEFAULT_GCP_PROJECT_ID
+    sample_agent_address = "agent-sales.support@example-org.com"
+    another_agent_address = "agent-billing_department+extra@another-entity.co.uk"
+
+    print("Starting Pub/Sub provisioning script example...")
+    print("-----------------------------------------------")
+    print(f"Using GCP Project ID: {gcp_project_id}")
+    print("Note: This script will attempt to interact with Google Cloud Pub/Sub.")
+    print("Ensure you have authenticated with 'gcloud auth application-default login'")
+    print("and the 'google-cloud-pubsub' library is installed.")
+    print("-----------------------------------------------\n")
+
+    # Demonstrate name generation
+    print("Name Generation Examples:")
+    test_address = "test-agent@example.com"
+    print(f"  For Address: {test_address}")
+    print(f"    Topic Name: {generate_topic_name(test_address)}")
+    print(f"    DLQ Topic Name: {generate_dlq_topic_name(test_address)}")
+    print(f"    Subscription Name: {generate_subscription_name(test_address)}")
+    print(f"    Subscription Name (custom consumer): {generate_subscription_name(test_address, consumer_group_id='analytics-v1')}")
+
+
+    # Provision for the sample agent
+    # In a real environment, these calls would be triggered by an agent registration process.
+    # For this script, we simulate it.
+    # IMPORTANT: Running this will attempt to create resources in your GCP project.
+    #            Comment out if you don't want to create actual resources.
+    try:
+        provision_agent_inbox(sample_agent_address, gcp_project_id)
+        provision_agent_inbox(another_agent_address, gcp_project_id)
+    except Exception as e:
+        print(f"\nAn error occurred during provisioning: {e}")
+        print("Please ensure your GCP environment is configured correctly.")
+
+    print("\n-----------------------------------------------")
+    print("Pub/Sub provisioning script example finished.")
+
+    # A note on sanitization for topic names:
+    # Pub/Sub topic names must start with a letter, and contain only letters (a-z, A-Z),
+    # numbers (0-9), dashes (-), periods (.), underscores (_), tildes (~), plus signs (+),
+    # and percent signs (%). They must be between 3 and 255 characters long.
+    # The hashing approach helps ensure uniqueness and avoids most character issues.
+    # The chosen names (e.g., "agent-inbox-<hash>") conform to these rules as hashes are
+    # hex strings and hyphens are allowed.
+    # The prefix "agent-inbox-" starts with a letter.
+    # The length of SHA256 hex is 64 chars. Prefixes add ~15-20 chars. Total length is well within limits.
+    #
+    # Sanitization in _sanitize_and_hash_address:
+    # The task: "convert the aiAgentAddress to lowercase, replace non-alphanumeric characters with hyphens,
+    # and then take a SHA-256 hash of the result".
+    # My implementation of _sanitize_and_hash_address:
+    # 1. `sanitized_address = ai_agent_address.lower()` - converts to lowercase.
+    # 2. `sanitized_address = re.sub(r"[^a-z0-9\-]", "-", sanitized_address)` - replaces non-alphanumeric
+    #    (excluding hyphen itself as it's a common separator) with hyphens.
+    #    This means `.` and `@` in emails will become hyphens.
+    #    e.g., `agent-sales.support@example-org.com` -> `agent-sales-support-example-org-com`
+    # 3. `sanitized_address = re.sub(r"-+", "-", sanitized_address)` - collapses multiple hyphens.
+    # 4. `sanitized_address = sanitized_address.strip('-')` - removes leading/trailing hyphens.
+    # This sanitized string is then hashed. This seems to align with the requirement.
+    # The hash itself will be alphanumeric, so it's safe for Pub/Sub names.
+    # The prefixes like "agent-inbox-" are also safe.
+```


### PR DESCRIPTION
This commit introduces a Python script and documentation for dynamically provisioning Google Cloud Pub/Sub topics and subscriptions to serve as inboxes for AI agents.

Key features:
- Python script (`gcp/pubsub_setup/pubsub_provisioning.py`):
  - Generates unique, sanitized names for topics, subscriptions, and Dead Letter Queues (DLQs) using SHA-256 hashing of agent addresses.
  - Programmatically creates Pub/Sub topics for agent inboxes and DLQs.
  - Programmatically creates Pub/Sub pull subscriptions configured with DLQs (5 max delivery attempts, 10s ack deadline, 7d retention).
  - Includes an example of how to use the provisioning functions.
- README.md (`gcp/pubsub_setup/README.md`):
  - Details the naming conventions and address sanitization/hashing logic.
  - Lists Pub/Sub and DLQ configuration parameters.
  - Outlines conceptual IAM roles for interacting components.
  - Provides instructions for using the Python script and equivalent `gcloud` commands for manual verification and setup.

This aligns with Task 03, setting up the foundational Pub/Sub infrastructure for the AI Agent Message Routing Component.