### PR TITLE
feat: Implement Message Ingestion API for Router Service

### DIFF
--- a/services/router/README.md
+++ b/services/router/README.md
@@ -1,0 +1,99 @@
+# Message Router Service
+
+This directory contains the implementation for the Message Router Service, specifically the core logic for the `POST /v1/messages` API endpoint.
+
+## 1. Core Logic (`message_router_service.py`)
+
+The `message_router_service.py` file implements the `handle_message_ingestion(request_payload)` function, which is the heart of the message ingestion API.
+
+### Logic Flow:
+
+1.  **Receive Request**: The function accepts an incoming `request_payload` dictionary, which is expected to conform to the API specification:
+    ```json
+    {
+      "aiAgentAddress": "string",
+      "payload": {}, // JSON object
+      "senderMetadata": { // Optional
+        "serviceName": "string",
+        "correlationId": "string",
+        "senderProvidedMessageId": "string"
+      }
+    }
+    ```
+
+2.  **Generate `messageId`**: A unique UUID (v4) is generated for the incoming message. This ID is used in the Pub/Sub message attributes and returned in the API response.
+
+3.  **Input Validation**:
+    *   Checks if `aiAgentAddress` is present, is a non-empty string.
+    *   Checks if `payload` is present and is a JSON object.
+    *   If validation fails, a `400 Bad Request` response is returned with a JSON error body (e.g., `{"errorCode": "INVALID_REQUEST", "message": "..."}`).
+
+4.  **CAMS Lookup**:
+    *   A stubbed `CAMSClient` is used, which internally calls the `getAgentMapping(aiAgentAddress)` function (conceptually from `services.cams.cams_api_pseudo.py`).
+    *   This lookup retrieves the agent's details, including their status and Pub/Sub `inboxName`.
+
+5.  **Conditional Routing & Error Handling**:
+    *   **Agent Not Found**: If `getAgentMapping` returns `None`, a `404 Not Found` response is returned (`{"errorCode": "AGENT_NOT_FOUND", ...}`).
+    *   **Agent Inactive**: If the agent's `status` is `INACTIVE`, a `404 Not Found` response is returned (`{"errorCode": "AGENT_INACTIVE", ...}`).
+    *   **Agent Active but `inboxName` Missing**: If the agent is `ACTIVE` but the `inboxName` (Pub/Sub topic) is missing from the CAMS record, a `500 Internal Server Error` is returned (`{"errorCode": "CONFIG_ERROR", ...}`).
+    *   **Unknown Agent Status**: If the agent's `status` is neither `ACTIVE` nor `INACTIVE`, a `500 Internal Server Error` is returned.
+
+6.  **Transform to Pub/Sub Message (for Active Agents)**:
+    *   The `request_payload.payload` is JSON stringified and then Base64 encoded to form the `data` field of the Pub/Sub message.
+    *   The `attributes` field of the Pub/Sub message is populated with:
+        *   `messageId` (generated UUID)
+        *   `aiAgentAddress` (from the request)
+        *   `timestampPublished` (current UTC timestamp in ISO 8601 format)
+        *   `contentType` (hardcoded to `"application/json"` for the MVP)
+        *   Optional attributes from `request_payload.senderMetadata`: `senderId` (from `serviceName`), `correlationId`, `senderProvidedMessageId`.
+    *   If an error occurs during this transformation, a `500 Internal Server Error` is returned (`{"errorCode": "TRANSFORMATION_ERROR", ...}`).
+
+7.  **Publish to Pub/Sub**:
+    *   A stubbed `PubSubPublisher` is used. Its `publish_message(topic_name, message_data)` method is called with the `inboxName` from CAMS and the transformed message.
+    *   **Error Handling**: If the stubbed publish operation "fails" (simulated via a flag in the stub), a `500 Internal Server Error` is returned (`{"errorCode": "PUB_SUB_ERROR", ...}`).
+
+8.  **Return Success Response**:
+    *   If the message is successfully "published" to Pub/Sub, a `202 Accepted` response is returned with the generated `messageId`:
+        ```json
+        {
+          "messageId": "generated-uuid-12345"
+        }
+        ```
+
+### Helper Functions:
+*   `create_json_response(data, status_code)`: A utility to format the response dictionary that would be converted to an actual HTTP JSON response by a web framework.
+*   Basic logging is implemented using the `logging` module to track key events and errors.
+
+## 2. Stubbed Clients
+
+*   **`CAMSClient`**:
+    *   Provides a `get_agent_mapping(ai_agent_address)` method.
+    *   It wraps the `getAgentMapping` function, which is imported from `services.cams.cams_api_pseudo`. A local mock of `getAgentMapping` is also included within `message_router_service.py` as a fallback if the import fails, allowing the service to be tested more independently.
+*   **`PubSubPublisher`**:
+    *   Provides a `publish_message(topic_name, message_data)` method.
+    *   This is a conceptual placeholder for a real Google Cloud Pub/Sub publisher client.
+    *   It includes a `simulate_failure` flag that can be set to `True` to test the Pub/Sub error handling path.
+
+## 3. Assumptions
+
+*   **CAMS Availability**: The CAMS client (`getAgentMapping`) is expected to be available and follow the interface defined in Task 02 (returning a dictionary with `status`, `inboxName`, etc., or `None`).
+*   **Pub/Sub Client Availability**: A Pub/Sub client mechanism is assumed to be available for publishing messages. The stub simulates this interaction.
+*   **Framework Agnostic**: The provided code is the core logic and does not include framework-specific boilerplate (like Flask or FastAPI routing setup). The `handle_message_ingestion` function would be called by the request handler of such a framework.
+*   **Error Response Format**: Error responses are JSON objects with `errorCode` and `message` fields, e.g., `{"errorCode": "AGENT_NOT_FOUND", "message": "AI Agent Address '...' not found."}`.
+*   **Logging**: Basic logging to stdout is used. In a production system, this would be more sophisticated.
+
+## 4. Example Usage (`if __name__ == "__main__":`)
+
+The `message_router_service.py` file includes an `if __name__ == "__main__":` block that demonstrates the usage of `handle_message_ingestion` with various scenarios:
+*   Valid request and successful processing.
+*   Agent not found in CAMS.
+*   Agent found but is inactive.
+*   Missing `aiAgentAddress` or `payload` in the request.
+*   Invalid `payload` format (not a JSON object).
+*   Simulated error during Pub/Sub publishing.
+*   Valid request with minimal or no `senderMetadata`.
+*   Scenario where CAMS returns an active agent but `inboxName` is missing (configuration error).
+
+These examples use `assert` statements for basic verification of the expected outcomes (status codes and error codes).
+
+This service fulfills the requirements for the Message Ingestion API of the Message Router Service as outlined in Task 04.

--- a/services/router/message_router_service.py
+++ b/services/router/message_router_service.py
@@ -1,0 +1,373 @@
+# services/router/message_router_service.py
+
+import json
+import uuid
+import base64
+from datetime import datetime, timezone
+import logging
+
+# Attempt to import CAMS client from the specified path
+try:
+    from services.cams.cams_api_pseudo import getAgentMapping
+except ImportError:
+    print("WARN: CAMS API pseudo-code not found at services.cams.cams_api_pseudo. Using mock CAMS client.")
+    # Define a mock getAgentMapping if the import fails (e.g., during isolated testing or if path is wrong)
+    def getAgentMapping(ai_agent_address: str):
+        print(f"MOCK CAMS: getAgentMapping called for {ai_agent_address}")
+        if ai_agent_address == "active-agent@example.com":
+            return {
+                "aiAgentAddress": ai_agent_address,
+                "inboxDestinationType": "GCP_PUBSUB_TOPIC",
+                "inboxName": "projects/your-gcp-project/topics/active-agent-inbox",
+                "status": "ACTIVE",
+                "lastHealthCheckTimestamp": None,
+                "registrationTimestamp": datetime.now(timezone.utc).isoformat(),
+                "lastUpdatedTimestamp": datetime.now(timezone.utc).isoformat(),
+                "updatedBy": "system",
+                "description": "Mock active agent",
+                "ownerTeam": "Mock Team"
+            }
+        elif ai_agent_address == "inactive-agent@example.com":
+            return {
+                "aiAgentAddress": ai_agent_address,
+                "inboxDestinationType": "GCP_PUBSUB_TOPIC",
+                "inboxName": "projects/your-gcp-project/topics/inactive-agent-inbox",
+                "status": "INACTIVE",
+                # ... other fields
+            }
+        return None
+
+# Configure basic logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+# --- HTTP Response Helper ---
+def create_json_response(data, status_code):
+    """
+    Helper to create a dictionary representing a JSON response.
+    In a real framework (Flask/FastAPI), this would return an actual HTTP response object.
+    """
+    return {"statusCode": status_code, "body": data}
+
+# --- CAMS Client Stub ---
+class CAMSClient:
+    def get_agent_mapping(self, ai_agent_address: str):
+        """
+        Wrapper for the CAMS getAgentMapping function.
+        """
+        logging.info(f"CAMSClient: Looking up agent mapping for {ai_agent_address}")
+        return getAgentMapping(ai_agent_address)
+
+cams_client = CAMSClient()
+
+# --- Pub/Sub Publisher Stub ---
+class PubSubPublisher:
+    def __init__(self, project_id: str):
+        self.project_id = project_id
+        # In a real scenario, this would initialize the Google Cloud Pub/Sub client
+        # from google.cloud import pubsub_v1
+        # self.publisher_client = pubsub_v1.PublisherClient()
+        logging.info(f"PubSubPublisher: Initialized for project {project_id} (STUB)")
+        self.simulate_failure = False # For testing error handling
+
+    def publish_message(self, topic_name: str, message_data: dict):
+        """
+        Publishes a message to the specified Pub/Sub topic.
+        This is a stub implementation.
+        `topic_name` here is the full topic path like "projects/your-project/topics/your-topic"
+        `message_data` is the dictionary conforming to Pub/Sub message structure {"data": "...", "attributes": {...}}
+        """
+        if self.simulate_failure:
+            logging.error(f"PubSubPublisher: SIMULATED FAILURE publishing to {topic_name}")
+            raise Exception("Simulated Pub/Sub publishing error")
+
+        # In a real implementation:
+        # data_bytes = message_data['data'].encode('utf-8') # Assuming data is already base64 string, Pub/Sub client handles this
+        # attributes = message_data['attributes']
+        # future = self.publisher_client.publish(topic_name, data=data_bytes, **attributes)
+        # future.result() # Wait for publish to complete (or handle asynchronously)
+
+        logging.info(f"PubSubPublisher: STUBBED Publishing message to topic '{topic_name}'. Message attributes: {message_data.get('attributes')}")
+        return True # Simulate success
+
+# Initialize a conceptual Pub/Sub publisher
+# In a real app, project_id would come from config
+pubsub_publisher = PubSubPublisher(project_id="your-gcp-project")
+
+
+# --- Core Message Ingestion Logic ---
+def handle_message_ingestion(request_payload: dict):
+    """
+    Handles the ingestion of an incoming message.
+    """
+    logging.info(f"handle_message_ingestion: Received request: {request_payload}")
+
+    # 1. Generate messageId
+    message_id = str(uuid.uuid4())
+    logging.info(f"Generated messageId: {message_id}")
+
+    # 2. Input Validation
+    ai_agent_address = request_payload.get("aiAgentAddress")
+    payload_content = request_payload.get("payload")
+
+    if not ai_agent_address or not isinstance(ai_agent_address, str) or not ai_agent_address.strip():
+        logging.warning("Validation failed: aiAgentAddress is missing or invalid.")
+        return create_json_response(
+            {"errorCode": "INVALID_REQUEST", "message": "aiAgentAddress is required and must be a non-empty string."},
+            400
+        )
+
+    if payload_content is None: # Checking for None explicitly, as {} is a valid payload
+        logging.warning("Validation failed: payload is missing.")
+        return create_json_response(
+            {"errorCode": "INVALID_REQUEST", "message": "payload is required."},
+            400
+        )
+
+    if not isinstance(payload_content, dict):
+        logging.warning("Validation failed: payload must be a JSON object.")
+        return create_json_response(
+            {"errorCode": "INVALID_REQUEST", "message": "payload must be a JSON object."},
+            400
+        )
+
+    # 3. CAMS Lookup
+    agent_mapping = cams_client.get_agent_mapping(ai_agent_address)
+
+    # 4. Conditional Routing Logic
+    if not agent_mapping:
+        logging.warning(f"Agent not found in CAMS: {ai_agent_address}")
+        return create_json_response(
+            {"errorCode": "AGENT_NOT_FOUND", "message": f"AI Agent Address '{ai_agent_address}' not found."},
+            404
+        )
+
+    if agent_mapping.get("status") == "INACTIVE":
+        logging.warning(f"Agent '{ai_agent_address}' is INACTIVE.")
+        return create_json_response(
+            {"errorCode": "AGENT_INACTIVE", "message": f"AI Agent '{ai_agent_address}' is currently inactive."},
+            404 # As per requirements, 404 for inactive agent
+        )
+
+    if agent_mapping.get("status") != "ACTIVE":
+        logging.error(f"Agent '{ai_agent_address}' has an unknown status: {agent_mapping.get('status')}")
+        return create_json_response(
+            {"errorCode": "INTERNAL_SERVER_ERROR", "message": f"AI Agent '{ai_agent_address}' has an unknown status."},
+            500
+        )
+
+    # Scenario C: Agent Found and ACTIVE
+    pubsub_topic_name = agent_mapping.get("inboxName")
+    if not pubsub_topic_name:
+        logging.error(f"Agent '{ai_agent_address}' is ACTIVE but has no inboxName defined in CAMS.")
+        return create_json_response(
+            {"errorCode": "CONFIG_ERROR", "message": "Agent configuration error: inboxName missing."},
+            500
+        )
+
+    # 5. Transform to Pub/Sub Message
+    try:
+        # 5.1. Prepare 'data' field (Base64 encode the original payload)
+        payload_string = json.dumps(payload_content)
+        payload_base64_bytes = base64.b64encode(payload_string.encode('utf-8'))
+        pubsub_data = payload_base64_bytes.decode('utf-8')
+
+        # 5.2. Prepare 'attributes'
+        pubsub_attributes = {
+            "messageId": message_id,
+            "aiAgentAddress": ai_agent_address,
+            "timestampPublished": datetime.now(timezone.utc).isoformat(timespec='milliseconds').replace('+00:00', 'Z'),
+            "contentType": "application/json" # Fixed for MVP as per Task 01
+        }
+
+        sender_metadata = request_payload.get("senderMetadata", {})
+        if isinstance(sender_metadata, dict):
+            if "serviceName" in sender_metadata:
+                pubsub_attributes["senderId"] = sender_metadata["serviceName"]
+            if "correlationId" in sender_metadata:
+                pubsub_attributes["correlationId"] = sender_metadata["correlationId"]
+            if "senderProvidedMessageId" in sender_metadata:
+                pubsub_attributes["senderProvidedMessageId"] = sender_metadata["senderProvidedMessageId"]
+
+        transformed_message = {
+            "data": pubsub_data,
+            "attributes": pubsub_attributes
+        }
+        logging.info(f"Transformed message for Pub/Sub: {transformed_message['attributes']}")
+
+    except Exception as e:
+        logging.error(f"Error during message transformation: {e}", exc_info=True)
+        return create_json_response(
+            {"errorCode": "TRANSFORMATION_ERROR", "message": "Failed to transform message for Pub/Sub."},
+            500
+        )
+
+    # 6. Publish to Pub/Sub
+    try:
+        pubsub_publisher.publish_message(pubsub_topic_name, transformed_message)
+        logging.info(f"Message {message_id} successfully published to topic {pubsub_topic_name} for agent {ai_agent_address}")
+    except Exception as e:
+        logging.error(f"Failed to publish message {message_id} to Pub/Sub topic {pubsub_topic_name}: {e}", exc_info=True)
+        return create_json_response(
+            {"errorCode": "PUB_SUB_ERROR", "message": "Failed to publish message to Pub/Sub."},
+            500
+        )
+
+    # 7. Return Success
+    return create_json_response({"messageId": message_id}, 202)
+
+
+# --- Example Usage / Basic Test Cases ---
+if __name__ == "__main__":
+    print("--- Message Router Service: Test Scenarios ---")
+
+    # Scenario 1: Valid Request
+    print("\n[Scenario 1: Valid Request]")
+    valid_request = {
+      "aiAgentAddress": "active-agent@example.com",
+      "payload": {"command": "processData", "value": 42},
+      "senderMetadata": {
+        "serviceName": "CRM_System",
+        "correlationId": "crm-corr-123",
+        "senderProvidedMessageId": "crm-msg-abc"
+      }
+    }
+    response = handle_message_ingestion(valid_request)
+    print(f"Response: {response}")
+    assert response["statusCode"] == 202
+    assert "messageId" in response["body"]
+
+    # Scenario 2: Agent Not Found
+    print("\n[Scenario 2: Agent Not Found]")
+    not_found_request = {
+      "aiAgentAddress": "unknown-agent@example.com",
+      "payload": {"command": "doSomething"}
+    }
+    response = handle_message_ingestion(not_found_request)
+    print(f"Response: {response}")
+    assert response["statusCode"] == 404
+    assert response["body"]["errorCode"] == "AGENT_NOT_FOUND"
+
+    # Scenario 3: Inactive Agent
+    print("\n[Scenario 3: Inactive Agent]")
+    inactive_agent_request = {
+      "aiAgentAddress": "inactive-agent@example.com",
+      "payload": {"command": "doSomethingElse"}
+    }
+    response = handle_message_ingestion(inactive_agent_request)
+    print(f"Response: {response}")
+    assert response["statusCode"] == 404 # As per requirement for inactive
+    assert response["body"]["errorCode"] == "AGENT_INACTIVE"
+
+    # Scenario 4: Missing aiAgentAddress
+    print("\n[Scenario 4: Missing aiAgentAddress]")
+    missing_address_request = {
+      # "aiAgentAddress": "active-agent@example.com",
+      "payload": {"command": "processData"}
+    }
+    response = handle_message_ingestion(missing_address_request)
+    print(f"Response: {response}")
+    assert response["statusCode"] == 400
+    assert response["body"]["errorCode"] == "INVALID_REQUEST"
+
+    # Scenario 5: Missing payload
+    print("\n[Scenario 5: Missing payload]")
+    missing_payload_request = {
+      "aiAgentAddress": "active-agent@example.com"
+      # "payload": {"command": "processData"}
+    }
+    response = handle_message_ingestion(missing_payload_request)
+    print(f"Response: {response}")
+    assert response["statusCode"] == 400
+    assert response["body"]["errorCode"] == "INVALID_REQUEST"
+
+    # Scenario 5b: Payload not a JSON object
+    print("\n[Scenario 5b: Payload not a JSON object]")
+    invalid_payload_request = {
+      "aiAgentAddress": "active-agent@example.com",
+      "payload": "not a dict"
+    }
+    response = handle_message_ingestion(invalid_payload_request)
+    print(f"Response: {response}")
+    assert response["statusCode"] == 400
+    assert response["body"]["errorCode"] == "INVALID_REQUEST"
+    assert "payload must be a JSON object" in response["body"]["message"]
+
+
+    # Scenario 6: Pub/Sub Publish Error
+    print("\n[Scenario 6: Pub/Sub Publish Error]")
+    pubsub_publisher.simulate_failure = True # Trigger failure in stub
+    pubsub_fail_request = {
+      "aiAgentAddress": "active-agent@example.com",
+      "payload": {"command": "criticalTask"},
+      "senderMetadata": {"serviceName": "CriticalService"}
+    }
+    response = handle_message_ingestion(pubsub_fail_request)
+    print(f"Response: {response}")
+    assert response["statusCode"] == 500
+    assert response["body"]["errorCode"] == "PUB_SUB_ERROR"
+    pubsub_publisher.simulate_failure = False # Reset simulation
+
+    # Scenario 7: Valid request with minimal senderMetadata
+    print("\n[Scenario 7: Valid Request, minimal senderMetadata]")
+    valid_request_minimal_meta = {
+      "aiAgentAddress": "active-agent@example.com",
+      "payload": {"data": "sample"},
+      "senderMetadata": {} # Empty but present
+    }
+    response = handle_message_ingestion(valid_request_minimal_meta)
+    print(f"Response: {response}")
+    assert response["statusCode"] == 202
+    assert "messageId" in response["body"]
+
+    # Scenario 8: Valid request, no senderMetadata
+    print("\n[Scenario 8: Valid Request, no senderMetadata]")
+    valid_request_no_meta = {
+      "aiAgentAddress": "active-agent@example.com",
+      "payload": {"data": "another sample"}
+    }
+    response = handle_message_ingestion(valid_request_no_meta)
+    print(f"Response: {response}")
+    assert response["statusCode"] == 202
+    assert "messageId" in response["body"]
+
+    # Scenario 9: CAMS returns active agent but no inboxName (config error)
+    print("\n[Scenario 9: Agent Active but no inboxName in CAMS mapping]")
+    # Temporarily modify mock CAMS for this test case
+
+    # Declare global intent before assignment if we are rebinding the global name
+    # However, the issue is more about how the functions are defined and used.
+    # Let's ensure the global cams_client uses the modified getAgentMapping.
+
+    # Store the original method from the global cams_client instance
+    original_cams_client_get_mapping_method = cams_client.get_agent_mapping
+
+    def mock_cams_get_mapping_for_no_inbox_test(ai_agent_address: str):
+        if ai_agent_address == "active-no-inbox@example.com":
+            logging.info("MOCK CAMS (Scenario 9): Returning agent with no inboxName")
+            return {
+                "aiAgentAddress": ai_agent_address,
+                "status": "ACTIVE",
+                "inboxName": None, # Missing inboxName
+                # other fields can be minimal for this test
+            }
+        # Fallback for other agents if necessary, though this test is specific
+        return original_cams_client_get_mapping_method(ai_agent_address)
+
+    # Temporarily replace the method on the global cams_client instance
+    cams_client.get_agent_mapping = mock_cams_get_mapping_for_no_inbox_test
+
+    try:
+        no_inbox_request = {
+            "aiAgentAddress": "active-no-inbox@example.com",
+            "payload": {"data": "test"}
+        }
+        response = handle_message_ingestion(no_inbox_request)
+        print(f"Response: {response}")
+        assert response["statusCode"] == 500
+        assert response["body"]["errorCode"] == "CONFIG_ERROR", f"Expected CONFIG_ERROR, got {response['body'].get('errorCode')}"
+    finally:
+        # Restore the original method on the global cams_client instance
+        cams_client.get_agent_mapping = original_cams_client_get_mapping_method
+
+
+    print("\n--- All test scenarios completed. ---")


### PR DESCRIPTION
Implements the core logic for the POST /v1/messages endpoint in the Message Router Service.

Key features:
- Receives incoming messages.
- Generates a unique messageId.
- Validates request payload (aiAgentAddress, payload).
- Looks up aiAgentAddress in CAMS (using a stubbed client).
- Handles CAMS responses: agent not found, agent inactive.
- Transforms messages to Pub/Sub schema (base64 payload, attributes).
- Publishes to Pub/Sub topic from CAMS (using a stubbed publisher).
- Returns 202 Accepted on success, or appropriate error (400, 404, 500).
- Includes basic logging and example test cases within the script.

The CAMS client and Pub/Sub publisher are stubbed as per requirements for this task, allowing the core routing logic to be developed and tested independently. A README is provided detailing the implementation.